### PR TITLE
fix: fixed when the analytics needs to be invalidated

### DIFF
--- a/app/actions/problems.ts
+++ b/app/actions/problems.ts
@@ -42,7 +42,6 @@ export const toggleFavorite = async ({
     });
     revalidatePath(`/${username}`);
     revalidatePath("/favorites");
-    revalidatePath("/analytics");
   } catch (error) {
     if (error instanceof PrismaClientKnownRequestError) {
       return Response.json("Problem not found for the user", { status: 404 });
@@ -61,6 +60,7 @@ export const syncWithLeetCode = async () => {
     await Promise.all(syncPromises);
 
     revalidatePath("/[username]", "page");
+    revalidatePath("/analytics");
     return { success: true, error: null };
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
The `/analytics` route should be invalidated when the user syncs with Leetcode.