### PR TITLE
Send compressed backup over curl request and create the file in GitHub action

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -2,8 +2,7 @@ name: Backup DB
 
 on:
   schedule:
-    # NOTE: This has been updated to every 5 minutes to verify the GitHub action run.
-    - cron: "5 * * * *"
+    - cron: "* * * * *"
 
 jobs:
   backup:
@@ -12,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: curl --request POST "${{ secrets.BASE_URL }}/api/backup"
+      - run: curl "${{ secrets.BASE_URL }}/api/backup" --request POST --create-dirs --output backup/data.json.gz
       - run: |
           git config --local user.email "abhayvashokan@gmail.com"
           git config --local user.name "Abhay V Ashokan"

--- a/app/api/backup/route.ts
+++ b/app/api/backup/route.ts
@@ -1,6 +1,5 @@
 import prisma from "@/lib/prisma";
 import zlib from "zlib";
-import fs from "fs";
 
 export async function POST() {
   try {
@@ -10,15 +9,12 @@ export async function POST() {
       prisma.topic.findMany(),
     ]);
 
-    if (!fs.existsSync("backup")) {
-      fs.mkdirSync("backup");
-    }
-
     const data = JSON.stringify({ users, problems, topics });
-    fs.writeFileSync("backup/data.json.gz", zlib.gzipSync(data));
-
-    return Response.json({
-      message: `Backup completed at ${new Date().toLocaleString("en-UK")}`,
+    return new Response(zlib.gzipSync(data), {
+      headers: {
+        "Content-Type": "text/json",
+        "Content-Encoding": "gzip",
+      },
     });
   } catch (error) {
     return Response.json({ error });


### PR DESCRIPTION
Creating the file within the curl request makes zero sense since it would create the file in the server. Instead, we need to get the compressed information from the curl request and commit the changes through GitHub actions server.